### PR TITLE
EF計算関数の追加

### DIFF
--- a/libcoffee/metrics/enrichment_factor.py
+++ b/libcoffee/metrics/enrichment_factor.py
@@ -113,16 +113,16 @@ if __name__ == "__main__":
 
     print("Scores:", y_score_example)
 
-    # Strict approach: top 25% => top 2 samples
+    # Strict approach: top 12.5% => top 1 samples
     ef_strict, frac_strict = enrichment_factor_score(
-        y_true_example, y_score_example, fraction=0.15, tie_handling="strict"
+        y_true_example, y_score_example, fraction=0.125, tie_handling="strict"
     )
-    print("[strict] EF(25%):", ef_strict)
+    print("[strict] EF(12.5%):", ef_strict)
     print("[strict] Actual fraction used:", frac_strict)
 
-    # Expand approach: top 25% => might include more if there's a tie at the boundary
+    # Expand approach: top 12.5% => might include more if there's a tie at the boundary
     ef_expand, frac_expand = enrichment_factor_score(
-        y_true_example, y_score_example, fraction=0.15, tie_handling="expand"
+        y_true_example, y_score_example, fraction=0.125, tie_handling="expand"
     )
-    print("[expand] EF(25%):", ef_expand)
+    print("[expand] EF(12.5%):", ef_expand)
     print("[expand] Actual fraction used:", frac_expand)


### PR DESCRIPTION
EFの計算を各自実装していたと思われる？ので、関数を作成しました。
通常考えられる `y_true`, `y_score`, `fraction` に加え、 `tie_handling` 引数を設定しています。
これは、scoreが同率であった時に、どのように処理をするか？というモノです。

ChatGPT先生に言わせると、この引数はこのようなモノだそうです。（うーん、サンプルっていう単語を誤用している気がするけど…）
```
 tie_handling : {"strict", "expand"}
            - "strict": fraction から求めたサンプル数 top_n を厳密に使用。
            - "expand": top_n 番目のスコアと同じスコアを持つサンプルが次にあれば、それらも含める。
```